### PR TITLE
docs: fix README clone URL for current repo owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ AutoDiscovery/
 
 ```bash
 # Clone the repository
-git clone git@github.com:bytewizard42i/AutoDiscovery.git
+git clone git@github.com:SpyCrypto/AutoDiscovery.git
 cd AutoDiscovery
 
 # Install all dependencies (monorepo)


### PR DESCRIPTION
## Summary
- update the Quick Start clone command in README
- point clone URL to the current repository owner ()

## Why
The previous command referenced a different GitHub owner, which can mislead new contributors and break copy/paste setup.

## Testing
- verified README diff contains only the clone URL update